### PR TITLE
Fix composer array issue with plain array as returned by composer getConfig getRepositories

### DIFF
--- a/src/Commands/RefactorComposerCommand.php
+++ b/src/Commands/RefactorComposerCommand.php
@@ -189,7 +189,7 @@ class RefactorComposerCommand extends BaseCommand {
     $projectPackage = $composer->getPackage();
     $projectPackageRequires = $projectPackage->getRequires();
     $projectPackageExtras = $projectPackage->getExtra();
-    $projectPackageRepos = $projectPackage->getRepositories();
+    $projectPackageRepos = $composer->getConfig()->getRepositories();
     $projectScripts = $projectPackage->getScripts();
     $projectPackagePatches = [];
     $continue = true;


### PR DESCRIPTION
Should fix 
`PHP Fatal error:  Uncaught Error: Cannot use object of type Composer\Repository\PackageRepository as array in /var/www/html/example.com/drupal/vendor/vardot/varbase-updater/src/Commands/RefactorComposerCommand.php:616`

`$projectPackage->getRepositories();` returns an array of `Composer\Repository\PackageRepository` instances - but we want a plain array as returned by `$composer->getConfig()->getRepositories();`