### PR TITLE
Adjust composer-patches version check - attempted fix for #63

### DIFF
--- a/src/Commands/VersionCheckComposerCommand.php
+++ b/src/Commands/VersionCheckComposerCommand.php
@@ -218,11 +218,9 @@ class VersionCheckComposerCommand extends BaseCommand {
     switch ($type) {
       case "composer-patches":
         if (!defined('cweagans\Composer\PatchEvents::PATCH_APPLY_ERROR')) {
-          exit(1);
+          print "You are using cweagans\composer-patches 1.x - unable to auto-handle patching failures.\n";
         }
-        else {
-          exit(0);
-        }
+        exit(0);
       break;
       case "current":
         print $versionInfo["current"];


### PR DESCRIPTION
I think we can get away without a complete failure here since the event handling is added conditionally.
And the hard fail breaks compatibility vardot/varbase: https://github.com/Vardot/varbase-updater/issues/63